### PR TITLE
feat: hiding icon on active line when editing

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,3 @@
-
-
 .link-favicon {
 	vertical-align: bottom;
 	margin-bottom: 0.3em;
@@ -26,4 +24,8 @@
 .link-favicon-scrollable-content {
 	overflow: auto;
 	height: 60vh;
+}
+
+.markdown-source-view .cm-active.cm-line img.link-favicon {
+	display: none !important;
 }


### PR DESCRIPTION
The favicon sometimes gets in the way when editing text around a link and can jump around. This is particularly challenging on mobile. This hides the icon on the current active line.

I debated putting this behavior behind a flag in settings, but my experience is that displaying the icon while editing the current line is more trouble than it's worth.